### PR TITLE
git deploy refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,14 @@ Default is `false`.
 
 ### Step 4b - Git setup
 
-First be sure that you have already placed your project under revision
-control using git.
-
-For example, for the default values of remote="master" and
-branch="gh-pages", the output of `git branch -a` should look like:
-
-      gh-pages
-    * master
-      remotes/origin/HEAD -> origin/master
-      remotes/origin/gh-pages
-      remotes/origin/master
-
-This shows that "gh-pages" exists in the remote and local repos. There
-needs to be at least one commit in "gh-pages" with which to start.
-
 Edit `config.rb`, and add:
 
     activate :deploy do |deploy|
       deploy.method = :git
     end
+
+With this default configuration, it will deploy to the "origin/gh-pages" branch of
+your current repo.
 
 #### These settings are optional.
 
@@ -85,15 +73,16 @@ To use a particular remote, add:
 
       deploy.remote = "some-other-remote-name"
 
-Default is `origin`. Run `git remote -v` to see a list of possible
-remotes.
+Default is `origin`. You can add a remote or a git url.
+Run `git remote -v` to see a list of possible remotes or add a new one first.
+If you specify a git url, be sure it ends with '.git'.
 
 To use a particular branch, add:
 
       deploy.branch = "some-other-branch-name"
 
-Default is `gh-pages`. Run `git branch -a` to see a list of possible
-branches.
+Default is `gh-pages`. If the branch doesn't exist remote, it will be created
+for you.
 
 ### Step 4c - FTP setup
 

--- a/middleman-deploy.gemspec
+++ b/middleman-deploy.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("middleman-core", [">= 3.0.0"])
 
   # Additional dependencies
-  s.add_runtime_dependency("git", "~> 1.2.0")
   s.add_runtime_dependency("ptools")
 end


### PR DESCRIPTION
hello tom,

:sparkles: I fixed the whole git deploy process to make it more robust and flexbile. :sparkles:

What the new version can do further than the current one:
- remove deleted files on remote
- handle updates on remote which aren't already pulled
- handle config.rb changes
- handle empty commits (if I want to deploy to trigger github pages build but didn't changed anything on the site)
- handle possible errors (it pushes with force :facepunch: )
- a user can specify a remote name _or_ a git url in config.rb, middleman-deploy will handle it
- handle if the remote branch we want to deploy doesn' exist and create it

What I changed:
- removed the dependency to the git gem since it is very old, unmaintained and we can't use more sophisticated git commands with it
- use shelled out plain git commands
- removed the git backport to the local repo, since the repo we can push to could be something else
- put the git repo for deploying in the build folder, no need to add a tmp repo everytime we deploy (and its easier/faster to keep track of the remote repo)
- updated the README with my crazy german-english grammar (maybe you can have a special look on this part :smiley_cat: )

cheers,

ben :sparkling_heart: 
