### PR TITLE
git: remove origin fetching, fixes #9

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -147,11 +147,9 @@ EOF
             end
           end
 
-          `git fetch origin`
-
-          #if there is a remote branch with that name, reset to it, otherwise just create a new one
-          if `git branch -r`.split("\n").keep_if{ |r| r =~ Regexp.new(branch,true) }.count > 0
-            `git reset --hard origin/#{branch}`
+          #if there is a branch with that name, switch to it, otherwise create a new one and switch to it
+          if `git branch`.split("\n").keep_if{ |r| r =~ Regexp.new(branch,true) }.count > 0
+            `git checkout #{branch}`
           else
             `git checkout -b #{branch}`
           end


### PR DESCRIPTION
Ok, I tried it and can reproduce this error.
I think, I added this for keeping remote (unpulled) changes of your co-worker or someone else for example, but its obviously not working. 

I removed this part for now. That means, the user is responsible if he's not pulling before changing anything and therefore could probably remove other's changes from the remote repo. He will at least get an error if he is trying to push to their page's source repo, needs to merge and deploy again, with all changes.

:sparkling_heart: Thanks for reporting :pizza: :beers: 
