### PR TITLE
[deploy_ftp] Add support for hidden files.

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -177,7 +177,8 @@ EOF
         ftp.passive = true
 
         Dir.chdir('build/') do
-          Dir['**/*'].each do |f|
+          files = Dir.glob('**/*', File::FNM_DOTMATCH)
+          files.reject { |a| a =~ Regexp.new('\.$') }.each do |f|
             if File.directory?(f)
               begin
                 ftp.mkdir(f)


### PR DESCRIPTION
When you are deploying via ftp, hidden files (for example `.htaccess`) are ignored. I add the support for dotfiles. I'm not sure if it's the best way, but it works fine.
