### PR TITLE
Very small bugfix to make middleman deploy work on ruby 1.8

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -154,7 +154,7 @@ EOF
           end
 
           #if there is a branch with that name, switch to it, otherwise create a new one and switch to it
-          if `git branch`.split("\n").keep_if{ |r| r =~ Regexp.new(branch,true) }.count > 0
+          if `git branch`.split("\n").delete_if{ |r| r =~ Regexp.new(branch,true) }.count == 0
             `git checkout #{branch}`
           else
             `git checkout -b #{branch}`


### PR DESCRIPTION
.keep_if is not present in Ruby 1.8, using delete_if and reversing the test should be equivalent and more universal.
