### PR TITLE
(optionally) force a build before any deploy

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -28,6 +28,7 @@ module Middleman
       :aliases => "-c",
       :desc => "Remove orphaned files or directories on the remote host"
       def deploy
+        Middleman::Cli::Build.new.build if self.deploy_options.force_build
         send("deploy_#{self.deploy_options.method}")
       end
 

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Deploy
 
-    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :after_build); end
+    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :after_build, :force_build); end
 
     class << self
 
@@ -23,6 +23,7 @@ module Middleman
         options.branch ||= "gh-pages"
 
         options.after_build ||= false
+        options.force_build ||= false
 
         app.after_build do |builder|
           ::Middleman::Cli::Deploy.new.deploy if options.after_build


### PR DESCRIPTION
Hi, the ability to force a fresh build before deploying was a feature I wanted in middleman-deploy, so i added it. It's a pretty small change, but I'm open to feedback + suggestions.
