### PR TITLE
Fix branch selection logic for git deploys

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -158,7 +158,7 @@ EOF
           end
 
           #if there is a branch with that name, switch to it, otherwise create a new one and switch to it
-          if `git branch`.split("\n").delete_if{ |r| r =~ Regexp.new(branch,true) }.count == 0
+          if `git branch`.split("\n").any? { |b| b =~ /#{branch}/i }
             `git checkout #{branch}`
           else
             `git checkout -b #{branch}`


### PR DESCRIPTION
- Before, because the logic was revered (see
  c0e46393c656eac6e47a83f54041457e3c6a6923), a brand new deploy would
  result in assuming that the deploy branch existed when it actually
  did not. This would cause initial deploys to fail.
- This new logic is more concise, more readable, and still backwards
  compatible with ruby 1.8.
