### PR TITLE
Default to a clean build when build_before is used

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -36,7 +36,7 @@ module Middleman
         end
         if build_before
           # http://forum.middlemanapp.com/t/problem-with-the-build-task-in-an-extension
-          builder = ::Middleman::Cli::Build.new(args=[], options={:instrument=>false})
+          builder = ::Middleman::Cli::Build.new(args=[], options={ :clean => true, :instrument => false })
           builder.build
         end
         send("deploy_#{self.deploy_options.method}")


### PR DESCRIPTION
In middleman 3.1, middleman-core now (correctly) [defaults to running `--clean` builds](https://github.com/middleman/middleman/blob/master/CHANGELOG.md#310-highlights), but middleman-deploy does not run clean builds when `build_before` is turned on.  

middleman-deploy should match the defaults of middleman-core and ensure clean builds before a deploy.

Related to #24
