### PR TITLE
Compass warning during test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development do
 end
 
 group :test do
+  gem "compass"
   gem "cucumber"
   gem "fivemat"
   gem "aruba"


### PR DESCRIPTION
When running the test suite, the following warning is printed:

```
Compass not installed: cannot load such file -- sass
```
