### PR TITLE
Quotes-Fix - deploying/comitting to github on a windows machine is not woking 

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -185,6 +185,7 @@ EOF
           end
 
           `git add -A`
+          # '"message"' double quotes to fix windows issue
           `git commit --allow-empty -am '"Automated commit at #{Time.now.utc} by #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"'`
           `git push -f origin #{branch}`
         end

--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -185,7 +185,7 @@ EOF
           end
 
           `git add -A`
-          `git commit --allow-empty -am 'Automated commit at #{Time.now.utc} by #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}'`
+          `git commit --allow-empty -am '"Automated commit at #{Time.now.utc} by #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"'`
           `git push -f origin #{branch}`
         end
       end


### PR DESCRIPTION
Thank you for sharing your work!

There seems to be an issue on windows machines when using mm deploy with github that leads to following error:

```
## Deploying via git to remote="origin" and branch="master"
Switched to a new branch 'master'
fatal: Paths with -a does not make sense.
error: src refspec master does not match any.
error: failed to push some refs to 'git@github.com:sDaniel/sDaniel.github.io.git'
```

This error seems to be a similar one as decribed here: https://github.com/koffeinfrei/piston/commit/9bf98361c3048620379ec03460385a5b870adfcc
With the change in this commit mm deploy works on my Win 8 machine. Please review if it breaks stuff on linux/OSX and consider adding the change to your master.
