### PR TITLE
Refactor - extract deploy strategies out of commands

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -2,6 +2,8 @@ require "middleman-core/cli"
 
 require "middleman-deploy/extension"
 require "middleman-deploy/pkg-info"
+require "middleman-deploy/strategy"
+
 
 module Middleman
   module Cli
@@ -35,64 +37,33 @@ module Middleman
           # http://forum.middlemanapp.com/t/problem-with-the-build-task-in-an-extension
           run("middleman build") || exit(1)
         end
-        send("deploy_#{self.deploy_options.method}")
+
+        strategies.find(deploy_options.method).deploy(self.deploy_options, self.inst, self)
       end
 
       protected
 
-      def print_usage_and_die(message)
-        raise Error, "ERROR: " + message + "\n" + <<EOF
+      def strategies
+        ::Middleman::Deploy::Strategy
+      end      
 
-You should follow one of the four examples below to setup the deploy
-extension in config.rb.
+      def print_usage_and_die(message, strategy=nil)
+        usage = if strategy
+          [
+            "You should follow this example below to setup the deploy",
+            strategy.usage
+          ].join("\n")
+        else
+          [
+            "You should follow one of the four examples below to setup the deploy",
+            "extension in config.rb.\n",
+            *strategies.all.map(&:usage)
+          ].join("\n")
+        end
 
-# To deploy the build directory to a remote host via rsync:
-activate :deploy do |deploy|
-  deploy.method = :rsync
-  # host and path *must* be set
-  deploy.host = "www.example.com"
-  deploy.path = "/srv/www/site"
-  # user is optional (no default)
-  deploy.user = "tvaughan"
-  # port is optional (default is 22)
-  deploy.port  = 5309
-  # clean is optional (default is false)
-  deploy.clean = true
-end
+        error_message = "ERROR: #{message}\n\n#{usage}"
 
-# To deploy to a remote branch via git (e.g. gh-pages on github):
-activate :deploy do |deploy|
-  deploy.method = :git
-  # remote is optional (default is "origin")
-  # run `git remote -v` to see a list of possible remotes
-  deploy.remote = "some-other-remote-name"
-  # branch is optional (default is "gh-pages")
-  # run `git branch -a` to see a list of possible branches
-  deploy.branch = "some-other-branch-name"
-end
-
-# To deploy the build directory to a remote host via ftp:
-activate :deploy do |deploy|
-  deploy.method = :ftp
-  # host, user, passwword and path *must* be set
-  deploy.host = "ftp.example.com"
-  deploy.path = "/srv/www/site"
-  deploy.user = "tvaughan"
-  deploy.password = "secret"
-end
-
-# To deploy the build directory to a remote host via sftp:
-activate :deploy do |deploy|
-  deploy.method = :sftp
-  # host, user, passwword and path *must* be set
-  deploy.host = "sftp.example.com"
-  deploy.path = "/srv/www/site"
-  # user is optional (no default)
-  deploy.user = "tvaughan"
-  # password is optional (no default)
-  deploy.password = "secret"
-end
-EOF
+        raise Error, error_message
       end
 
       def inst
@@ -110,181 +81,19 @@ EOF
 
         if (!options.method)
           print_usage_and_die "The deploy extension requires you to set a method."
-        end
-
-        case options.method
-        when :rsync, :sftp
-          if (!options.host || !options.path)
-            print_usage_and_die "The #{options.method} method requires host and path to be set."
-          end
-        when :ftp
-          if (!options.host || !options.user || !options.password || !options.path)
-            print_usage_and_die "The ftp deploy method requires host, path, user, and password to be set."
+        else
+          strategy = strategies.find(options.method)
+          missing_options = strategy.required_options - options.members
+          unless missing_options.empty?
+            print_usage_and_die "Missing options: #{missing_options.join(", ")}", strategy
           end
         end
 
         options
       end
 
-      def deploy_rsync
-        host = self.deploy_options.host
-        port = self.deploy_options.port
-        path = self.deploy_options.path
-
-        # Append "@" to user if provided.
-        user = self.deploy_options.user
-        user = "#{user}@" if user && !user.empty?
-
-        dest_url = "#{user}#{host}:#{path}"
-
-        puts "## Deploying via rsync to #{dest_url} port=#{port}"
-
-        command = "rsync -avze '" + "ssh -p #{port}" + "' #{self.inst.build_dir}/ #{dest_url}"
-
-        if self.deploy_options.clean
-          command += " --delete"
-        end
-
-        run command
-      end
-
-      def deploy_git
-        remote = self.deploy_options.remote
-        branch = self.deploy_options.branch
-
-        puts "## Deploying via git to remote=\"#{remote}\" and branch=\"#{branch}\""
-
-        #check if remote is not a git url
-        unless remote =~ /\.git$/
-          remote = `git config --get remote.#{remote}.url`.chop
-        end
-
-        #if the remote name doesn't exist in the main repo
-        if remote == ''
-          puts "Can't deploy! Please add a remote with the name '#{self.deploy_options.remote}' to your repo."
-          exit
-        end
-
-        Dir.chdir(self.inst.build_dir) do
-          unless File.exists?('.git')
-            `git init`
-            `git remote add origin #{remote}`
-          else
-            #check if the remote repo has changed
-            unless remote == `git config --get remote.origin.url`.chop
-              `git remote rm origin`
-              `git remote add origin #{remote}`
-            end
-          end
-
-          #if there is a branch with that name, switch to it, otherwise create a new one and switch to it
-          if `git branch`.split("\n").any? { |b| b =~ /#{branch}/i }
-            `git checkout #{branch}`
-          else
-            `git checkout -b #{branch}`
-          end
-
-          `git add -A`
-          # '"message"' double quotes to fix windows issue
-          `git commit --allow-empty -am '"Automated commit at #{Time.now.utc} by #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"'`
-          `git push -f origin #{branch}`
-        end
-      end
-
-      def deploy_ftp
-        require 'net/ftp'
-        require 'ptools'
-
-        host = self.deploy_options.host
-        user = self.deploy_options.user
-        pass = self.deploy_options.password
-        path = self.deploy_options.path
-
-        puts "## Deploying via ftp to #{user}@#{host}:#{path}"
-
-        ftp = Net::FTP.new(host)
-        ftp.login(user, pass)
-        ftp.chdir(path)
-        ftp.passive = true
-
-        Dir.chdir(self.inst.build_dir) do
-          files = Dir.glob('**/*', File::FNM_DOTMATCH)
-          files.reject { |a| a =~ Regexp.new('\.$') }.each do |f|
-            if File.directory?(f)
-              begin
-                ftp.mkdir(f)
-                puts "Created directory #{f}"
-              rescue
-              end
-            else
-              begin
-                if File.binary?(f)
-                  ftp.putbinaryfile(f, f)
-                else
-                  ftp.puttextfile(f, f)
-                end
-              rescue Exception => e
-                reply = e.message
-                err_code = reply[0,3].to_i
-                if err_code == 550
-                  if File.binary?(f)
-                    ftp.putbinaryfile(f, f)
-                  else
-                    ftp.puttextfile(f, f)
-                  end
-                end
-              end
-              puts "Copied #{f}"
-            end
-          end
-        end
-        ftp.close
-      end
-
-      def deploy_sftp
-        require 'net/sftp'
-        require 'ptools'
-
-        host = self.deploy_options.host
-        user = self.deploy_options.user
-        pass = self.deploy_options.password
-        path = self.deploy_options.path
-
-        puts "## Deploying via sftp to #{user}@#{host}:#{path}"
-
-        # `nil` is a valid value for user and/or pass.
-        Net::SFTP.start(host, user, :password => pass) do |sftp|
-          sftp.mkdir(path)
-          Dir.chdir(self.inst.build_dir) do
-            files = Dir.glob('**/*', File::FNM_DOTMATCH)
-            files.reject { |a| a =~ Regexp.new('\.$') }.each do |f|
-              if File.directory?(f)
-                begin
-                  sftp.mkdir("#{path}/#{f}")
-                  puts "Created directory #{f}"
-                rescue
-                end
-              else
-                begin
-                  sftp.upload(f, "#{path}/#{f}")
-                rescue Exception => e
-                  reply = e.message
-                  err_code = reply[0,3].to_i
-                  if err_code == 550
-                    sftp.upload(f, "#{path}/#{f}")
-                  end
-                end
-                puts "Copied #{f}"
-              end
-            end
-          end
-        end
-      end
-
+      # Alias "d" to "deploy"
+      Base.map({ "d" => "deploy" })
     end
-
-    # Alias "d" to "deploy"
-    Base.map({ "d" => "deploy" })
-
   end
 end

--- a/lib/middleman-deploy/strategy.rb
+++ b/lib/middleman-deploy/strategy.rb
@@ -1,0 +1,17 @@
+module Middleman::Deploy::Strategy
+  class << self
+    def find(name)
+      strategy = all.find do |strategy| 
+        strategy.name.split('::').last.downcase == name.to_s
+      end 
+
+      strategy || (raise "#{name} is not supported")
+    end
+
+    def all
+      constants.collect{|const_name| const_get(const_name)}.select{|const| const.class == Module}
+    end
+  end
+end
+
+Dir["#{File.expand_path('../', __FILE__)}/strategy/*.rb"].each{ |f| require f }

--- a/lib/middleman-deploy/strategy/ftp.rb
+++ b/lib/middleman-deploy/strategy/ftp.rb
@@ -1,0 +1,71 @@
+module Middleman::Deploy::Strategy::FTP
+  extend self
+
+	def deploy(deploy_options, middleman_options, thor_context)
+		require 'net/ftp'
+		require 'ptools'
+
+		host = options.host
+		user = options.user
+		pass = options.password
+		path = options.path
+
+		puts "## Deploying via ftp to #{user}@#{host}:#{path}"
+
+		ftp = Net::FTP.new(host)
+		ftp.login(user, pass)
+		ftp.chdir(path)
+		ftp.passive = true
+
+		Dir.chdir(middleman_options.build_dir) do
+			files = Dir.glob('**/*', File::FNM_DOTMATCH)
+			files.reject { |a| a =~ Regexp.new('\.$') }.each do |f|
+				if File.directory?(f)
+					begin
+						ftp.mkdir(f)
+						puts "Created directory #{f}"
+					rescue
+					end
+				else
+					begin
+						if File.binary?(f)
+							ftp.putbinaryfile(f, f)
+						else
+							ftp.puttextfile(f, f)
+						end
+					rescue Exception => e
+						reply = e.message
+						err_code = reply[0,3].to_i
+						if err_code == 550
+							if File.binary?(f)
+								ftp.putbinaryfile(f, f)
+							else
+								ftp.puttextfile(f, f)
+							end
+						end
+					end
+					puts "Copied #{f}"
+				end
+			end
+		end
+		ftp.close
+	end
+
+  def usage
+    <<-EOS.gsub(/^ {6}/, '')
+      # To deploy the build directory to a remote host via ftp:
+      activate :deploy do |deploy|
+        deploy.method = :ftp
+        # host, user, passwword and path *must* be set
+        deploy.host = "ftp.example.com"
+        deploy.path = "/srv/www/site"
+        deploy.user = "tvaughan"
+        deploy.password = "secret"
+      end
+    EOS
+  end
+
+  def required_options
+    [:host, :path]
+  end
+end

--- a/lib/middleman-deploy/strategy/git.rb
+++ b/lib/middleman-deploy/strategy/git.rb
@@ -1,0 +1,66 @@
+module Middleman::Deploy::Strategy::Git
+  extend self
+
+  def deploy(deploy_options, middleman_options)
+
+    remote = deploy_options.remote
+    branch = deploy_options.branch
+
+    puts "## Deploying via git to remote=\"#{remote}\" and branch=\"#{branch}\""
+
+    #check if remote is not a git url
+    unless remote =~ /\.git$/
+      remote = `git config --get remote.#{remote}.url`.chop
+    end
+
+    #if the remote name doesn't exist in the main repo
+    if remote == ''
+      puts "Can't deploy! Please add a remote with the name '#{deploy_options.remote}' to your repo."
+      exit
+    end
+
+    Dir.chdir(middleman_options.build_dir) do
+      unless File.exists?('.git')
+        `git init`
+        `git remote add origin #{remote}`
+      else
+        #check if the remote repo has changed
+        unless remote == `git config --get remote.origin.url`.chop
+          `git remote rm origin`
+          `git remote add origin #{remote}`
+        end
+      end
+
+      #if there is a branch with that name, switch to it, otherwise create a new one and switch to it
+      if `git branch`.split("\n").any? { |b| b =~ /#{branch}/i }
+        `git checkout #{branch}`
+      else
+        `git checkout -b #{branch}`
+      end
+
+      `git add -A`
+      # '"message"' double quotes to fix windows issue
+      `git commit --allow-empty -am '"Automated commit at #{Time.now.utc} by #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"'`
+      `git push -f origin #{branch}`
+    end
+  end
+
+  def usage
+    <<-EOS.gsub(/^ {6}/, '')
+      # To deploy to a remote branch via git (e.g. gh-pages on github):
+      activate :deploy do |deploy|
+        deploy.method = :git
+        # remote is optional (default is "origin")
+        # run `git remote -v` to see a list of possible remotes
+        deploy.remote = "some-other-remote-name"
+        # branch is optional (default is "gh-pages")
+        # run `git branch -a` to see a list of possible branches
+        deploy.branch = "some-other-branch-name"
+      end
+    EOS
+  end
+
+  def required_options
+    []
+  end
+end

--- a/lib/middleman-deploy/strategy/rsync.rb
+++ b/lib/middleman-deploy/strategy/rsync.rb
@@ -1,0 +1,47 @@
+module Middleman::Deploy::Strategy::RSync
+  extend self
+
+	def deploy(deploy_options, middleman_options, thor_context)
+		host = deploy_options.host
+		port = deploy_options.port
+		path = deploy_options.path
+
+    # Append "@" to user if provided.
+    user = deploy_options.user
+    user = "#{user}@" if user && !user.empty?
+
+    dest_url = "#{user}#{host}:#{path}"
+
+    puts "## Deploying via rsync to #{dest_url} port=#{port}"
+
+    command = "rsync -avze '" + "ssh -p #{port}" + "' #{middleman_options.build_dir}/ #{dest_url}"
+
+    if deploy_options.clean
+    	command += " --delete"
+    end
+
+    thor_context.run command
+  end
+
+  def usage
+    <<-EOS.gsub(/^ {6}/, '')
+      # To deploy the build directory to a remote host via rsync:
+      activate :deploy do |deploy|
+        deploy.method = :rsync
+        # host and path *must* be set
+        deploy.host = "www.example.com"
+        deploy.path = "/srv/www/site"
+        # user is optional (no default)
+        deploy.user = "tvaughan"
+        # port is optional (default is 22)
+        deploy.port  = 5309
+        # clean is optional (default is false)
+        deploy.clean = true
+      end
+    EOS
+  end
+
+  def required_options
+    [:host, :path]
+  end
+end

--- a/lib/middleman-deploy/strategy/sftp.rb
+++ b/lib/middleman-deploy/strategy/sftp.rb
@@ -1,0 +1,63 @@
+module Middleman::Deploy::Strategy::SFTP
+  extend self
+
+  def deploy(deploy_options, middleman_options, thor_context)
+    require 'net/sftp'
+    require 'ptools'
+
+    host = deploy_options.host
+    user = deploy_options.user
+    pass = deploy_options.password
+    path = deploy_options.path
+
+    puts "## Deploying via sftp to #{user}@#{host}:#{path}"
+
+    # `nil` is a valid value for user and/or pass.
+    Net::SFTP.start(host, user, :password => pass) do |sftp|
+      sftp.mkdir(path)
+      Dir.chdir(middleman_options.build_dir) do
+        files = Dir.glob('**/*', File::FNM_DOTMATCH)
+        files.reject { |a| a =~ Regexp.new('\.$') }.each do |f|
+          if File.directory?(f)
+            begin
+              sftp.mkdir("#{path}/#{f}")
+              puts "Created directory #{f}"
+            rescue
+            end
+          else
+            begin
+              sftp.upload(f, "#{path}/#{f}")
+            rescue Exception => e
+              reply = e.message
+              err_code = reply[0,3].to_i
+              if err_code == 550
+                sftp.upload(f, "#{path}/#{f}")
+              end
+            end
+            puts "Copied #{f}"
+          end
+        end
+      end
+    end
+  end
+
+  def usage
+    <<-EOS.gsub(/^ {6}/, '')
+      # To deploy the build directory to a remote host via sftp:
+      activate :deploy do |deploy|
+        deploy.method = :sftp
+        # host, user, passwword and path *must* be set
+        deploy.host = "sftp.example.com"
+        deploy.path = "/srv/www/site"
+        # user is optional (no default)
+        deploy.user = "tvaughan"
+        # password is optional (no default)
+        deploy.password = "secret"
+      end
+    EOS
+  end
+
+  def required_options(options)
+    [:host, :path]
+  end
+end


### PR DESCRIPTION
Hey

I want to add support for multiple deployment profiles, something like:

```
activate :deploy do |deploy|
    deploy.profiles.add("github") do |profile|
        profile.method = :git
    end
    deploy.profiles.add("heroku") do |profile|
        profile.method = :git
        profile.remote = "heroku"
        profile.branch = "master"
    end
end
```

Having looked at the code it seemed like it would be easier to do if I extracted the deploy methods out first, this pull request is for that. I thought it would be good to get the structure nailed down before adding the multi-profile support.

NB: I've only got git repos to test against so I haven't tested ftp, sftp or rsync. I've tried to avoid changing the implementations as much as possible but someone with a project set up for the other methods should probably try them before merging :)
