### PR TITLE
Add support for SFTP using pem key (such as on EC2) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ activate :deploy do |deploy|
   # Optional Settings
   # deploy.user     = "tvaughan" # no default
   # deploy.password = "secret" # no default
+  # deploy.key_path = "path/to/private.pem" # no default
 end
 ```
 

--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -91,6 +91,8 @@ activate :deploy do |deploy|
   deploy.user = "tvaughan"
   # password is optional (no default)
   deploy.password = "secret"
+  # ssh key file path is optional (no default)
+  deploy.key_path = "path/to/key.pem"
 end
 EOF
       end
@@ -249,11 +251,12 @@ EOF
         user = self.deploy_options.user
         pass = self.deploy_options.password
         path = self.deploy_options.path
+        keys = self.deploy_options.key_path
 
         puts "## Deploying via sftp to #{user}@#{host}:#{path}"
 
         # `nil` is a valid value for user and/or pass.
-        Net::SFTP.start(host, user, :password => pass) do |sftp|
+        Net::SFTP.start(host, user, :password => pass, :keys => keys) do |sftp|
           sftp.mkdir(path)
           Dir.chdir(self.inst.build_dir) do
             files = Dir.glob('**/*', File::FNM_DOTMATCH)

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Deploy
 
-    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :build_before); end
+    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :key_path, :clean, :remote, :branch, :build_before); end
 
     class << self
 


### PR DESCRIPTION
Achieved by adding a `key_path` option fo the configuration. This path gets passed on tot he `Net::SFTP.start` method, which handles it from there.
