### PR TITLE
Adding "flags" option for rsync 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ activate :deploy do |deploy|
   # deploy.user  = "tvaughan" # no default
   # deploy.port  = 5309 # ssh port, default: 22
   # deploy.clean = true # remove orphaned files on remote host, default: false
+  # deploy.flags = "-rltgoDvzO --no-p --del -e" # add custom flags, default: -avze
 end
 ```
 

--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -139,7 +139,9 @@ EOF
 
         puts "## Deploying via rsync to #{dest_url} port=#{port}"
 
-        command = "rsync -avze '" + "ssh -p #{port}" + "' #{self.inst.build_dir}/ #{dest_url}"
+        flags = !self.deploy_options.flags ? '-avze' : self.deploy_options.flags
+
+        command = "rsync " + flags + " '" + "ssh -p #{port}" + "' #{self.inst.build_dir}/ #{dest_url}"
 
         if self.deploy_options.clean
           command += " --delete"

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Deploy
 
-    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :build_before); end
+    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :build_before, :flags); end
 
     class << self
 


### PR DESCRIPTION
The 'flags' option adds the flexibility to customize flags instead of being forced to use the -azve option. If the item is left blank -azve will be used as the default. 
