### PR TITLE
Add strategy option to git method

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ following to `config.rb`:
 activate :deploy do |deploy|
   deploy.method = :git
   # Optional Settings
-  # deploy.remote = "custom-remote" # remote name or git url, default: origin
-  # deploy.branch = "custom-branch" # default: gh-pages
+  # deploy.remote   = "custom-remote" # remote name or git url, default: origin
+  # deploy.branch   = "custom-branch" # default: gh-pages
+  # deploy.strategy = :submodule      # commit strategy: can be :force_push or :submodule, default: :force_push
 end
 ```
 
@@ -72,8 +73,12 @@ If you use a remote name, you must first add it using `git remote add`. Run
 `git remote -v` to see a list of possible remote names. If you use a git url,
 it must end with '.git'.
 
-Afterwards, the `build` directory will become a git repo. This branch will be
-created on the remote if it doesn't already exist.
+Afterwards, the `build` directory will become a git repo.
+
+If you use the force push strategy, this branch will be created on the remote if
+it doesn't already exist.
+But if you use the submodule strategy, you must first initialize build folder as
+a submodule. See `git submodule add` documentation.
 
 ### FTP
 

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Deploy
 
-    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :build_before, :flags); end
+    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :strategy, :build_before, :flags); end
 
     class << self
 
@@ -22,8 +22,9 @@ module Middleman
         options.clean ||= false
 
         # Default options for the git method.
-        options.remote ||= "origin"
-        options.branch ||= "gh-pages"
+        options.remote    ||= "origin"
+        options.branch    ||= "gh-pages"
+        options.strategy  ||= :force_push
 
         options.build_before ||= false
 


### PR DESCRIPTION
Here is a proposal of a strategy option for the git deployment method. Its value can be either `:force_push` or `:submodule`.

If you use the force push strategy, a branch will be created on the remote if it doesn't already exist and then a force push will be made to the remote branch. But if you use the submodule strategy, a fetch and rebase will be made before any commit and push to the remote branch. The default is kept to `:force_push`.

In my use case, the build folder is a submodule of development branch. That way I can push changes to my build branch from elsewhere than the build folder.

Please tell me if this could be useful to other people.
