### PR TITLE
add port reader for ftp method

### DIFF
--- a/lib/middleman-deploy/methods/ftp.rb
+++ b/lib/middleman-deploy/methods/ftp.rb
@@ -6,7 +6,7 @@ module Middleman
     module Methods
       class Ftp < Base
 
-        attr_reader :host, :pass, :path,:user
+        attr_reader :host, :port, :pass, :path, :user
 
         def initialize(server_instance, options={})
           super(server_instance, options)


### PR DESCRIPTION
self.port didn't work in sftp method as no port attr_reader in ftp method
