### PR TITLE
Use binary transfer mode for all files to prevent corrupt images when deploying via FTP

### DIFF
--- a/lib/middleman-deploy/methods/ftp.rb
+++ b/lib/middleman-deploy/methods/ftp.rb
@@ -27,10 +27,8 @@ module Middleman
             filtered_files.each do |filename|
               if File.directory?(filename)
                 upload_directory(ftp, filename)
-              elsif File.binary?(filename)
+              else 
                 upload_binary(ftp, filename)
-              else
-                upload_file(ftp, filename)
               end
             end
           end
@@ -85,16 +83,7 @@ module Middleman
           rescue
           end
         end
-
-        def upload_file(ftp, filename)
-          begin
-            ftp.puttextfile(filename, filename)
-          rescue Exception => exception
-            handle_exception(exception, ftp, filename)
-          end
-
-          puts "Copied #{filename}"
-        end
+        
 
       end
     end


### PR DESCRIPTION
As @noniq mentioned in https://github.com/tvaughan/middleman-deploy/issues/19#issuecomment-35843507 using binary transfer mode for all files prevents corrupt images when deploying via FTP 

Works like a charme for me
