### PR TITLE
No method 'run' in rsync.rb

### DIFF
--- a/lib/middleman-deploy/methods/rsync.rb
+++ b/lib/middleman-deploy/methods/rsync.rb
@@ -29,7 +29,7 @@ module Middleman
           end
 
           puts "## Deploying via rsync to #{dest_url} port=#{self.port}"
-          run command
+          exec command
         end
 
       end


### PR DESCRIPTION
I encountered issue https://github.com/tvaughan/middleman-deploy/issues/58 as well while trying to deploy with ruby 2.1.1.

I'm not too sure where run comes from. As far as I know, it's not one of the commands used to execute commands in ruby. I just replaced 'run' with 'exec' to get middleman deploy via rsync working.

Does anyone know how rsync.rb worked before? 
