### PR TITLE
Tiny change to README to suggest using 'system' over 'exec'

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ end
 namespace :deploy do
   def deploy(env)
     puts "Deploying to #{env}"
-    exec "TARGET=#{env} bundle exec middleman deploy"
+    system "TARGET=#{env} bundle exec middleman deploy"
   end
 
   task :staging do


### PR DESCRIPTION
Reason being, 'exec' will run the shell command and then exit the ruby
process. While 'system will run the shell command and then continue
execution.

I feel this is a better example as the first thing I did was write a
rake task that chains multiple tasks together and the way 'exec' was
ending the process cost me a bit of time trouble shooting why.
