### PR TITLE
Add support for deploying to more than one host for rsync, sftp and ftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,23 @@ end
     $ rake deploy:staging
     $ rake deploy:production
 
+
+## Deploying to multiple hosts
+
+The methods `:rsync`, `:ftp` and `:sftp` also support a deployment to multiple hosts. To achieve this, you must first make sure that users, ports and directories are the same on all servers. Then, set the `host` to an Array of all the hosts you want to deploy to:
+
+```ruby
+activate :deploy do |deploy|
+  deploy.method   = :sftp
+  deploy.host     = ["sftp.example.com", "sftp2.example.com"]
+  deploy.port     = 22
+  deploy.path     = "/srv/www/site"
+  # Optional Settings
+  # deploy.user     = "tvaughan" # no default
+  # deploy.password = "secret" # no default
+end
+```
+
 ## Breaking Changes
 
 * `v0.1.0`

--- a/lib/middleman-deploy/methods/rsync.rb
+++ b/lib/middleman-deploy/methods/rsync.rb
@@ -3,24 +3,32 @@ module Middleman
     module Methods
       class Rsync < Base
 
-        attr_reader :clean, :flags, :host, :path, :port, :user
+        attr_reader :clean, :flags, :hosts, :path, :port, :user
 
         def initialize(server_instance, options={})
           super(server_instance, options)
 
           @clean  = self.options.clean
           @flags  = self.options.flags
-          @host   = self.options.host
+          @hosts  = [self.options.host].flatten
           @path   = self.options.path
           @port   = self.options.port
           @user   = self.options.user
         end
 
         def process
+          [hosts].flatten.each do |host|
+            process_host(host)
+          end
+        end
+
+        protected
+
+        def process_host(host)
           # Append "@" to user if provided.
           user      = "#{self.user}@" if self.user && !self.user.empty?
 
-          dest_url  = "#{user}#{self.host}:#{self.path}"
+          dest_url  = "#{user}#{host}:#{self.path}"
           flags     = self.flags || '-avz'
           command   = "rsync #{flags} '-e ssh -p #{self.port}' #{self.server_instance.build_dir}/ #{dest_url}"
 
@@ -29,7 +37,7 @@ module Middleman
           end
 
           puts "## Deploying via rsync to #{dest_url} port=#{self.port}"
-          exec command
+          system command
         end
 
       end

--- a/lib/middleman-deploy/methods/sftp.rb
+++ b/lib/middleman-deploy/methods/sftp.rb
@@ -6,11 +6,13 @@ module Middleman
     module Methods
       class Sftp < Ftp
 
-        def process
-          puts "## Deploying via sftp to #{self.user}@#{self.host}:#{path}"
+        protected
+
+        def process_host(host)
+          puts "## Deploying via sftp to #{self.user}@#{host}:#{path}"
 
           # `nil` is a valid value for user and/or pass.
-          Net::SFTP.start(self.host, self.user, :password => self.pass, :port => self.port) do |sftp|
+          Net::SFTP.start(host, self.user, :password => self.pass, :port => self.port) do |sftp|
             sftp.mkdir(self.path)
 
             Dir.chdir(self.server_instance.build_dir) do
@@ -25,7 +27,6 @@ module Middleman
           end
         end
 
-      protected
 
         def handle_exception(exception)
           reply     = exception.message


### PR DESCRIPTION
I recently needed to deploy to a load-balanced multi-node setup and had to adapt the code to make this work. Since we don't have any access to FTP or SFTP, I adapted these methods to, but could not test it, though the changes are pretty straight-forward. Maybe someone should do a quick test for that, too.

RSync works, I already deployed something.
