### PR TITLE
Add git-credentials features

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -30,6 +30,10 @@ activate :deploy do |deploy|
 
   # strategy is optional (default is :force_push)
   deploy.strategy = :submodule
+
+  # Git credentials helper (default is :none_helper)
+  deploy.credentials = :cache_helper
+  deploy.credentials_timeout = 3600 # (default is 12h)
 end
 
 # To deploy the build directory to a remote host via ftp:

--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -3,6 +3,7 @@ require "middleman-core/cli"
 require "middleman-deploy/extension"
 require "middleman-deploy/methods"
 require "middleman-deploy/strategies"
+require "middleman-deploy/credentials"
 require "middleman-deploy/pkg-info"
 
 module Middleman

--- a/lib/middleman-deploy/credentials.rb
+++ b/lib/middleman-deploy/credentials.rb
@@ -1,0 +1,2 @@
+require 'middleman-deploy/credentials/git/cache'
+require 'middleman-deploy/credentials/git/none'

--- a/lib/middleman-deploy/credentials/git/cache.rb
+++ b/lib/middleman-deploy/credentials/git/cache.rb
@@ -1,0 +1,27 @@
+
+module Middleman
+  module Deploy
+    module Credentials
+      module Git
+        class CacheHelper
+          attr_accessor :timeout
+          def initialize(timeout)
+            self.timeout = timeout
+          end
+          def save_credentials
+            unless credentials_active?
+              `git config --global credential.helper 'cache --timeout=#{timeout}' `
+              puts "Git credentials-helper has cached your data for #{timeout} seconds"
+            else
+              puts "Git credentials already active"
+            end
+          end
+
+          def credentials_active?
+            `git config --global credential.helper` != ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/middleman-deploy/credentials/git/none.rb
+++ b/lib/middleman-deploy/credentials/git/none.rb
@@ -1,0 +1,15 @@
+
+module Middleman
+  module Deploy
+    module Credentials
+      module Git
+        class NoneHelper
+          def initialize(*args); end
+          def save_credentials
+            # No implementation for none helper
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Deploy
 
-    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :strategy, :build_before, :flags, :commit_message); end
+    class Options < Struct.new(:whatisthis, :method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :strategy, :build_before, :flags, :commit_message, :credentials, :credentials_timeout); end
 
     class << self
 
@@ -26,7 +26,9 @@ module Middleman
         options.branch    ||= "gh-pages"
         options.strategy  ||= :force_push
         options.commit_message  ||= nil
-
+        options.credentials ||= :none_helper
+        options.credentials_timeout ||= 3600 * 12
+        
         options.build_before ||= false
 
         @@options = options

--- a/lib/middleman-deploy/methods/git.rb
+++ b/lib/middleman-deploy/methods/git.rb
@@ -11,6 +11,13 @@ module Middleman
           strategy_instance   = strategy_class_name.constantize.new(self.server_instance.build_dir, self.options.remote, self.options.branch, self.options.commit_message)
 
           strategy_instance.process
+
+          camelized_helper  = self.options.credentials.to_s.split('_').map { |word| word.capitalize}.join
+          helper_class_name = "Middleman::Deploy::Credentials::Git::#{camelized_helper}"
+          helper_instance = helper_class_name.constantize.new(self.options.credentials_timeout)
+
+          helper_instance.save_credentials
+
         end
 
       end


### PR DESCRIPTION
Add

> deploy.credentials = :cache_helper
> deploy.credentials_timeout = 3600

to config.rb of your static site and you'll have to insert your credentials once in a hour.

Don't know if the architecture design is the best to ensure a sort of extensibility to use credentials also with other methods (rsync, ftp). However it seems to run properly.
