### PR TITLE
Respect user details of git repo.

### DIFF
--- a/lib/middleman-deploy/strategies/git/base.rb
+++ b/lib/middleman-deploy/strategies/git/base.rb
@@ -3,13 +3,15 @@ module Middleman
     module Strategies
       module Git
         class Base
-          attr_accessor :branch, :build_dir, :remote, :commit_message
+          attr_accessor :branch, :build_dir, :remote, :commit_message, :user_name, :user_email
 
           def initialize(build_dir, remote, branch, commit_message)
             self.branch         = branch
             self.build_dir      = build_dir
             self.remote         = remote
             self.commit_message = commit_message
+            self.user_name      = `git config --get user.name`
+            self.user_email     = `git config --get user.email`
           end
 
           def process

--- a/lib/middleman-deploy/strategies/git/force_push.rb
+++ b/lib/middleman-deploy/strategies/git/force_push.rb
@@ -30,7 +30,7 @@ module Middleman
               end
               # check if the user name has changed
               `git config user.name "#{self.user_name}"` unless self.user_name == `git config --get user.name`
-              # check if the remote repo has changed
+              # check if the user email has changed
               `git config user.email "#{self.user_email}"` unless self.user_email == `git config --get user.email`
             end
           end

--- a/lib/middleman-deploy/strategies/git/force_push.rb
+++ b/lib/middleman-deploy/strategies/git/force_push.rb
@@ -20,12 +20,18 @@ module Middleman
             unless File.exists?('.git')
               `git init`
               `git remote add origin #{url}`
+              `git config user.name "#{self.user_name}"`
+              `git config user.name "#{self.user_email}"`
             else
               # check if the remote repo has changed
               unless url == `git config --get remote.origin.url`.chop
                 `git remote rm origin`
                 `git remote add origin #{url}`
               end
+              # check if the user name has changed
+              `git config user.name "#{self.user_name}"` unless self.user_name == `git config --get user.name`
+              # check if the remote repo has changed
+              `git config user.email "#{self.user_email}"` unless self.user_email == `git config --get user.email`
             end
           end
 


### PR DESCRIPTION
Currently deployment commit has global user name and email, disregarding settings of git repository.

This branch provides a fix.
