### PR TITLE
Prevent bad commits deploying. (git)

### DIFF
--- a/lib/middleman-deploy/strategies/git/base.rb
+++ b/lib/middleman-deploy/strategies/git/base.rb
@@ -37,9 +37,14 @@ module Middleman
           def commit_branch(options = '')
             message = self.commit_message ? self.commit_message : add_signature_to_commit_message('Automated commit')
 
-            `git add -A`
-            `git commit --allow-empty -am "#{message}"`
-            `git push #{options} origin #{self.branch}`
+            run_or_fail("git add -A")
+            run_or_fail("git commit --allow-empty -am \"#{message}\"")
+            run_or_fail("git push #{options} origin #{self.branch}")
+          end
+
+          private
+          def run_or_fail(command)
+            system(command) || raise("ERROR running: #{command}")
           end
         end
       end


### PR DESCRIPTION
Hi, thanks for building this handy gem. I don't know if the following change is worth merging, as it only covers 3 system calls and there isn't a test suite so skipped over writing any, but I wanted to raise awareness of an issue when you encounter a fatal error with git.

Using `git add -A`, if git encounters a fatal error, it will output to stderr, but won't halt the deployment from happening. The result of this is that you end up pushing nothing to your git repository, and blatting your live website in the process. This is just a simple guard to halt the deploy from completing if something goes wrong.
