### PR TITLE
Use the new build env on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,30 @@
 language: ruby
+
+sudo: false
+
 cache: bundler
-bundler_args: --without development
+
 rvm:
   - ruby-head
-  - ruby
   - jruby-head
   - jruby
-  - 2.1.0
+  - 2.1
   - 2.0.0
   - 1.9.3
   - rbx-2
+
+before_script: bundle update
+
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
-    - rvm: ruby
     - rvm: jruby-head
     - rvm: jruby
     - rvm: rbx-2
+
 notifications:
   email: false
+
 env:
   - CODECLIMATE_REPO_TOKEN=5eee8e8624962f963a52a1d2313dc7407e3b8006291e3704346c786642cc073b 


### PR DESCRIPTION
faster vms and more cpu and more ram and better boot times, etc etc

caching is available on this setup

removed 'ruby' as 1.9.3 is already there

make sure to bundle update the cache or you won't get the newest stuff
