### PR TITLE
Allow passing options to SSH command in rsync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ activate :deploy do |deploy|
   deploy.host          = 'www.example.com'
   deploy.path          = '/srv/www/site'
   # Optional Settings
-  # deploy.user  = 'tvaughan' # no default
-  # deploy.port  = 5309 # ssh port, default: 22
-  # deploy.clean = true # remove orphaned files on remote host, default: false
-  # deploy.flags = '-rltgoDvzO --no-p --del' # add custom flags, default: -avz
+  # deploy.user      = 'tvaughan' # no default
+  # deploy.port      = 5309 # ssh port, default: 22
+  # deploy.clean     = true # remove orphaned files on remote host, default: false
+  # deploy.flags     = '-rltgoDvzO --no-p --del' # add custom flags, default: -avz
+  # deploy.ssh_flags = '-o UserKnownHostsFile=~/.ssh/known_hosts' # add custom ssh flags, no default
 end
 ```
 

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -26,6 +26,7 @@ module Middleman
       option :build_before, nil
       option :flags, nil
       option :commit_message, nil
+      option :ssh_flags, nil
 
       def initialize(app, options_hash = {}, &block)
         super

--- a/lib/middleman-deploy/methods/rsync.rb
+++ b/lib/middleman-deploy/methods/rsync.rb
@@ -7,12 +7,13 @@ module Middleman
         def initialize(server_instance, options = {})
           super(server_instance, options)
 
-          @clean  = self.options.clean
-          @flags  = self.options.flags
-          @host   = self.options.host
-          @path   = self.options.path
-          @port   = self.options.port
-          @user   = self.options.user
+          @clean     = self.options.clean
+          @flags     = self.options.flags
+          @host      = self.options.host
+          @path      = self.options.path
+          @port      = self.options.port
+          @user      = self.options.user
+          @ssh_flags = self.options.ssh_flags
         end
 
         def process
@@ -21,7 +22,7 @@ module Middleman
 
           dest_url  = "#{user}#{host}:#{path}"
           flags     = self.flags || '-avz'
-          command   = "rsync #{flags} '-e ssh -p #{port}' #{build_dir}/ #{dest_url}"
+          command   = "rsync #{flags} '-e ssh -p #{port} #{@ssh_flags}' #{build_dir}/ #{dest_url}"
 
           command += ' --delete' if clean
 


### PR DESCRIPTION
The same method you use to pass flags to the rsync command itself would
be useful to the ssh command passed to rsync as the `-e ssh` flag.
