### PR TITLE
Allow specifying env

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -45,7 +45,7 @@ module Middleman
       end
 
       def deploy
-        env = options['environment'] ? :production : options['environment'].to_s.to_sym
+        env = options['environment'].to_s.to_sym
         verbose = options['verbose'] ? 0 : 1
         instrument = options['instrument']
 


### PR DESCRIPTION
The original code here:

```
        env = options['environment'] ? :production : options['environment'].to_s.to_sym
```

Looks backwards, as it will force env to always be production. Since you are defaulting the environment to production in the Thor args

```
      class_option :environment,
                 aliases: '-e',
                 default: ENV['MM_ENV'] || ENV['RACK_ENV'] || 'production',
```

you can simplify this.
