### PR TITLE
If deploy.user is set, use it also in rsync command

### DIFF
--- a/lib/middleman-deploy/methods/rsync.rb
+++ b/lib/middleman-deploy/methods/rsync.rb
@@ -17,7 +17,7 @@ module Middleman
 
         def process
           # Append "@" to user if provided.
-          user      = "#{self.user}@" if user && !user.empty?
+          user      = "#{self.user}@" if self.user && !self.user.empty?
 
           dest_url  = "#{user}#{host}:#{path}"
           flags     = self.flags || '-avz'


### PR DESCRIPTION
This PR fixes a small bug in the rsync strategy. If the user was explicitly set, it wasn't passed into the rsync command, due to local / global method / variable name clashes.
