### PR TITLE
Adds an option to rsync deployment method to specify the full path to the rsync binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ activate :deploy do |deploy|
   deploy.host          = 'www.example.com'
   deploy.path          = '/srv/www/site'
   # Optional Settings
-  # deploy.user  = 'tvaughan' # no default
-  # deploy.port  = 5309 # ssh port, default: 22
-  # deploy.clean = true # remove orphaned files on remote host, default: false
-  # deploy.flags = '-rltgoDvzO --no-p --del' # add custom flags, default: -avz
+  # deploy.user       = 'tvaughan' # no default
+  # deploy.port       = 5309 # ssh port, default: 22
+  # deploy.clean      = true # remove orphaned files on remote host, default: false
+  # deploy.flags      = '-rltgoDvzO --no-p --del' # add custom flags, default: -avz
+  # deploy.rsync_bin  = '/usr/local/bin/rsync' # specify which rsync binary to invoke if multiple versions are present
 end
 ```
 

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -26,6 +26,7 @@ module Middleman
       option :build_before, nil
       option :flags, nil
       option :commit_message, nil
+      option :rsync_bin, nil
 
       def initialize(app, options_hash = {}, &block)
         super

--- a/lib/middleman-deploy/methods/rsync.rb
+++ b/lib/middleman-deploy/methods/rsync.rb
@@ -2,17 +2,18 @@ module Middleman
   module Deploy
     module Methods
       class Rsync < Base
-        attr_reader :clean, :flags, :host, :path, :port, :user
+        attr_reader :clean, :flags, :host, :path, :port, :rsync_bin, :user
 
         def initialize(server_instance, options = {})
           super(server_instance, options)
 
-          @clean  = self.options.clean
-          @flags  = self.options.flags
-          @host   = self.options.host
-          @path   = self.options.path
-          @port   = self.options.port
-          @user   = self.options.user
+          @clean      = self.options.clean
+          @flags      = self.options.flags
+          @host       = self.options.host
+          @path       = self.options.path
+          @port       = self.options.port
+          @rsync_bin  = self.options.rsync_bin
+          @user       = self.options.user
         end
 
         def process
@@ -21,7 +22,8 @@ module Middleman
 
           dest_url  = "#{user}#{host}:#{path}"
           flags     = self.flags || '-avz'
-          command   = "rsync #{flags} '-e ssh -p #{port}' #{build_dir}/ #{dest_url}"
+          rsync_bin = self.rsync_bin || "rsync"
+          command   = "#{rsync_bin} #{flags} '-e ssh -p #{port}' #{build_dir}/ #{dest_url}"
 
           command += ' --delete' if clean
 

--- a/lib/middleman-deploy/pkg-info.rb
+++ b/lib/middleman-deploy/pkg-info.rb
@@ -21,6 +21,8 @@ activate :deploy do |deploy|
   deploy.clean = true
   # flags is optional (default is -avze)
   deploy.flags = "-rltgoDvzO --no-p --del -e"
+  # rsync_bin is option (default is rsync)
+  deploy.rsync_bin = "/usr/local/bin/rsync"
 end
 
 # To deploy to a remote branch via git (e.g. gh-pages on github):


### PR DESCRIPTION
This option is useful when deploying from Mac OS X. The latest Mac OS X (El Capitan) ships with a rsync binary from 2006.

My current use case is when deploying sites that have non-ASCII URLs (file names).
When deploying from Mac OS X to a Linux server the `--iconv=utf-8-mac,utf-8` rsync flag is required for properly naming the files on the server. This option, however, is present in rsync 3.0.0, while Mac OS X ships with 2.6.9. Thus I have to install rsync from homebrew and meddle with the PATH environment variable to point to the homebrew rsync. 
With this option I don't need to change the PATH environment variable but simply point to the version of rsync which I installed from homebrew.
