### PR TITLE
Fix user variable scoping

### DIFF
--- a/lib/middleman-deploy/methods/rsync.rb
+++ b/lib/middleman-deploy/methods/rsync.rb
@@ -17,7 +17,7 @@ module Middleman
 
         def process
           # Append "@" to user if provided.
-          user      = "#{self.user}@" if user && !user.empty?
+          user      = "#{self.user}@" if self.user && !self.user.empty?
 
           dest_url  = "#{user}#{host}:#{path}"
           flags     = self.flags || '-avz'


### PR DESCRIPTION
This is a fix for an issue I was experiencing when trying to deploy a Middleman site via rsync. You can see the project that benefited from this change here: [ngscheurich/ttk-site](https://github.com/ngscheurich/ttk-site/tree/b1bffbca1c5b44d294a48d54c1cf59d374370f58) (note that I am using my fork in the [Gemfile](https://github.com/ngscheurich/ttk-site/blob/b1bffbca1c5b44d294a48d54c1cf59d374370f58/Gemfile)).

A side note: I didn't have any luck running the test suite before submitting this PR. `bundle exec rake` generated a `cannot load such file -- middleman-core/cli (LoadError)` error. Do I need to do some setup before running the _test_ task?
