### PR TITLE
Fix environment flag

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -45,7 +45,7 @@ module Middleman
       end
 
       def deploy
-        env = options['environment'] ? :production : options['environment'].to_s.to_sym
+        env = options['environment'] ? options['environment'].to_s.to_sym : :production
         verbose = options['verbose'] ? 0 : 1
         instrument = options['instrument']
 


### PR DESCRIPTION
Why:

* The command environment flag `-e` is not setting the environment
  Middleman will run on. Instead it is always setting it to
  `production`.

This change addresses the issue by:

* Fixing the conditional that sets the environment to use the value
  passed in the option.