### PR TITLE
Fix instrument option type

### DIFF
--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -26,7 +26,7 @@ module Middleman
                    desc: 'Print debug messages'
 
       class_option :instrument,
-                   type: :string,
+                   type: :boolean,
                    default: false,
                    desc: 'Print instrument messages'
 


### PR DESCRIPTION
ref:
https://github.com/middleman/middleman/issues/2017#issuecomment-264615817
https://github.com/middleman/middleman/issues/2017#issuecomment-266758698

`class_option`'s type has to be set as correct one, otherwise new versions of Thor outputs warning messages.