### PR TITLE
Fixes to support Middleman 4.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 bin
+.rvmrc

--- a/lib/middleman-deploy/commands.rb
+++ b/lib/middleman-deploy/commands.rb
@@ -26,7 +26,7 @@ module Middleman
                    desc: 'Print debug messages'
 
       class_option :instrument,
-                   type: :string,
+                   type: :boolean,
                    default: false,
                    desc: 'Print instrument messages'
 

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -26,6 +26,7 @@ module Middleman
       option :build_before, nil
       option :flags, nil
       option :commit_message, nil
+      option :last_changed, nil
 
       def initialize(app, options_hash = {}, &block)
         super
@@ -43,6 +44,7 @@ module Middleman
         options.commit_message ||= nil
 
         options.build_before ||= false
+        options.last_changed ||= nil # all files
       end
 
       def after_configuration

--- a/lib/middleman-deploy/extension.rb
+++ b/lib/middleman-deploy/extension.rb
@@ -4,7 +4,7 @@ require 'middleman-core'
 # Extension namespace
 module Middleman
   module Deploy
-    class Options < Struct.new(:method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :strategy, :build_before, :flags, :commit_message); end
+    class Options < Struct.new(:method, :host, :port, :user, :password, :path, :clean, :remote, :branch, :strategy, :build_before, :flags, :commit_message, :last_changed); end
 
     class << self
       def options
@@ -24,6 +24,7 @@ module Middleman
         options.branch ||= 'gh-pages'
         options.strategy ||= :force_push
         options.commit_message  ||= nil
+        options.last_changed ||= nil
 
         options.build_before ||= false
 

--- a/lib/middleman-deploy/methods/ftp.rb
+++ b/lib/middleman-deploy/methods/ftp.rb
@@ -5,7 +5,7 @@ module Middleman
   module Deploy
     module Methods
       class Ftp < Base
-        attr_reader :host, :port, :pass, :path, :user
+        attr_reader :host, :port, :pass, :path, :user, :last_changed
 
         def initialize(server_instance, options = {})
           super(server_instance, options)
@@ -15,6 +15,7 @@ module Middleman
           @pass = self.options.password
           @path = self.options.path
           @port = self.options.port
+          @last_changed = self.options.last_changed
         end
 
         def process
@@ -41,6 +42,7 @@ module Middleman
           files = Dir.glob('**/*', File::FNM_DOTMATCH)
 
           files.reject { |filename| filename =~ Regexp.new('\.$') }
+          files.reject { |filename| File.ctime(filename) < last_changed } unless last_changed.nil?
         end
 
         def handle_exception(exception, ftp, filename)

--- a/lib/middleman-deploy/methods/ftp.rb
+++ b/lib/middleman-deploy/methods/ftp.rb
@@ -42,7 +42,9 @@ module Middleman
           files = Dir.glob('**/*', File::FNM_DOTMATCH)
 
           files.reject { |filename| filename =~ Regexp.new('\.$') }
-          files.reject { |filename| File.ctime(filename) < last_changed } unless last_changed.nil?
+          if last_changed.to_i > 0
+            files.reject { |filename| File.ctime(filename) < last_changed } unless last_changed.nil?
+          end
         end
 
         def handle_exception(exception, ftp, filename)


### PR DESCRIPTION
Fixes:
```RuntimeError: Tried to activate old-style extension: deploy. They are no longer supported.``` when trying to build.