### PR TITLE
fixes #72, #91 — getting git remote url

### DIFF
--- a/lib/middleman-deploy/strategies/git/force_push.rb
+++ b/lib/middleman-deploy/strategies/git/force_push.rb
@@ -35,21 +35,22 @@ module Middleman
           end
 
           def get_remote_url
-            remote  = self.remote
-            url     = remote
+            Dir.chdir('..') do
+              url = remote
 
-            # check if remote is not a git url
-            unless remote =~ /\.git$/
-              url = `git config --get remote.#{url}.url`.chop
+              # check if remote is not a git url
+              unless url.end_with?('.git')
+                url = `git config --get remote.#{remote}.url`.chop
+              end
+
+              # if the remote name doesn't exist in the main repo
+              if url == ''
+                puts "Can't deploy! Please add a remote with the name '#{remote}' to your repo."
+                exit
+              end
+
+              url
             end
-
-            # if the remote name doesn't exist in the main repo
-            if url == ''
-              puts "Can't deploy! Please add a remote with the name '#{remote}' to your repo."
-              exit
-            end
-
-            url
           end
         end
       end


### PR DESCRIPTION
Hi @karlfreeman,

I know that this likely won't be merged (I saw [the list of open PRs](https://github.com/karlfreeman/middleman-deploy/pulls)) but maybe it will help someone else.

The problem with issues #72 and #91 was, that the subrepository in the build directory can only be initialized the first time because there's no other git repository in the `build` folder yet. Afterwards `get_remote_url` will only get the data from git repository of the `build` folder, which might have a totally different origin name or url. Thus the `chdir('..')` to get to the main repository again.

The dependencies really should be updated, too (but [somebody else already took care on on this](https://github.com/karlfreeman/middleman-deploy/pull/128)).